### PR TITLE
Adding ./manage.py migrate to init rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ deps:
 	pip install -r requirements.txt
 
 init:
+	./manage.py migrate
 	./manage.py loaddata --app creatorz sample.json
 
 shell:


### PR DESCRIPTION
## Fixed
- Just make sure the `make init` rule creates the db and migrates